### PR TITLE
Add Jekyll SEO tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .sass-cache
 node_modules
 _site
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -15,4 +15,13 @@ sass:
 
 plugins:
   - jekyll-seo-tag
-  - jekyll-sitemap
+
+title: "👋  Hello, GitHub"
+description: "@natfriedman"
+
+twitter:
+  username: natfriedman
+
+author:
+  name: Nat Friedman
+  twitter: natfriedman

--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,7 @@ sass:
   style: compressed
   load_paths:
     - node_modules/
+
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ sass:
 plugins:
   - jekyll-seo-tag
 
-title: "👋  Hello, GitHub"
+title: "👋 Hello, GitHub"
 description: "@natfriedman"
 
 twitter:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,16 +2,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="author" content="Nat Friedman">
-    <meta name="generator" content="Jekyll v{{ jekyll.version }}">
-    <title>
-      {%- if page.title -%}
-        {{ page.title | smartify }}
-      {%- else -%}
-        {{ site.title | smartify }}
-      {%- endif -%}
-    </title>
     <link href="index.css" rel="stylesheet">
+    {% seo %}
   </head>
   <body>
     <div class="container-lg py-6">

--- a/index.md
+++ b/index.md
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: 👋 Hello, GitHub | @natfriedman
 ---
 
 # 👋 Hello, GitHub


### PR DESCRIPTION
:wave: Hello from a (soon to be) fellow GitHubber. Excited to have you on board. This pull request adds the "official" [Jekyll SEO plugin](https://github.com/jekyll/jekyll-seo-tag) to help add some additional metadata when the site is viewed or shared via social media.

It's largely a drop-in replacement for what's currently in the template, with some minor improvements to implement some SEO and social media best practices. You shouldn't have to do anything special or differently as a result.

### Before

```html
<meta name="author" content="Nat Friedman">
<meta name="generator" content="Jekyll v3.7.3">
<title>👋 Hello, GitHub | @natfriedman</title>
```

### After

```html
<!-- Begin Jekyll SEO tag v2.4.0 -->
<title>👋 Hello, GitHub | @natfriedman</title>
<meta name="generator" content="Jekyll v3.7.3" />
<meta property="og:title" content="👋 Hello, GitHub" />
<meta name="author" content="Nat Friedman" />
<meta property="og:locale" content="en_US" />
<meta name="description" content="@natfriedman" />
<meta property="og:description" content="@natfriedman" />
<link rel="canonical" href="http://localhost:4000/" />
<meta property="og:url" content="http://localhost:4000/" />
<meta property="og:site_name" content="👋 Hello, GitHub" />
<meta name="twitter:card" content="summary" />
<meta name="twitter:site" content="@natfriedman" />
<meta name="twitter:creator" content="@natfriedman" />
<script type="application/ld+json">
{"url":"http://localhost:4000/","author":{"@type":"Person","name":"Nat Friedman"},"description":"@natfriedman","name":"👋 Hello, GitHub","@type":"WebSite","headline":"👋 Hello, GitHub","@context":"http://schema.org"}</script>
<!-- End Jekyll SEO tag -->
```

This pull request also adds a Gemfile with [the GitHub Pages plugin](https://github.com/github/pages-gem), so that when previewing locally, the site more closely matched the Production environment.
